### PR TITLE
Set jurisdiction to AU to trigger flag warning

### DIFF
--- a/input/multi-lang.xml
+++ b/input/multi-lang.xml
@@ -28,8 +28,8 @@
   <description value="This IG exists to test out the generation of multi-language IGs. Primary language is en, also does nl, pt, and ar (rtl test)"/>
   <jurisdiction>
     <coding>
-      <system value="http://unstats.un.org/unsd/methods/m49/m49.htm"/>
-      <code value="001"/>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="AU"/>
     </coding>
   </jurisdiction>
   <packageId value="hl7.fhir.test.multi-lang"/>


### PR DESCRIPTION
Setting the flag triggers a lot of errors due to the missing national flag:

<img width="2015" height="975" alt="image" src="https://github.com/user-attachments/assets/fd62c622-ba96-4f50-81a9-94569d9d00b3" />
